### PR TITLE
rename expectNetworkRequestToHaveBeenMade to expectRequestToHaveBeenMade

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const loginRequest = mockRequest({
 // ... make a network request somewhere in your actual code ...
 // Use available methods on MockedRequest to make assertions
 // about how the network request has been made.
-loginRequest.expectNetworkRequestToHaveBeenMade()
+loginRequest.expectRequestToHaveBeenMade()
 ```
 
 ### Using mockRequest for graphQL
@@ -99,13 +99,13 @@ loginRequest.expectRequestMadeMatchingContract()
 
 Every time you mock a request, you get hold of this class which has the following methods:
 
-### expectNetworkRequestToHaveBeenMade
+### expectRequestToHaveBeenMade
 
 Asserts that the network request you mocked also has been called.
 
 ```js
 const loginRequest = mockRequest({/* mock details go here */})
-loginRequest.expectNetworkRequestToHaveBeenMade()
+loginRequest.expectRequestToHaveBeenMade()
 ```
 
 ### expectNetworkRequestToNotHaveBeenMade

--- a/src/MockedRequest.ts
+++ b/src/MockedRequest.ts
@@ -36,7 +36,7 @@ export class MockedRequest {
     }
 
     // PUBLIC METHODS **********************************************************
-    public expectNetworkRequestToHaveBeenMade() {
+    public expectRequestToHaveBeenMade() {
         this.expectNetworkRequestToHaveBeenMadeFactory(true)
     }
 
@@ -49,7 +49,7 @@ export class MockedRequest {
             this.stacktrace,
             passedInContract
         )
-        this.expectNetworkRequestToHaveBeenMade()
+        this.expectRequestToHaveBeenMade()
         const requestMade = mockedRequests[this.reference]
         const requestPayload = requestMade.body
         const contractUrlPieces = new URL(contract.request.url)
@@ -85,7 +85,7 @@ export class MockedRequest {
         requestPayload,
         requestHeaders,
     }: ExpectRequestMadeMatchingInput) {
-        this.expectNetworkRequestToHaveBeenMade()
+        this.expectRequestToHaveBeenMade()
         const requestMade = mockedRequests[this.reference]
         if (requestPayload) {
             compareRequestBodies(

--- a/src/tests/assertionHelpers.spec.ts
+++ b/src/tests/assertionHelpers.spec.ts
@@ -12,7 +12,7 @@ describe("Assertion Helpers", () => {
         await request({
             uri: "https://www.google.com/some/cities/here",
         })
-        citiesRequest.expectNetworkRequestToHaveBeenMade()
+        citiesRequest.expectRequestToHaveBeenMade()
     })
 
     it("Fails if expectation of network request having been made is incorrect", async () => {
@@ -23,7 +23,7 @@ describe("Assertion Helpers", () => {
         })
         let expectedErrorWhenRequestNotMade
         try {
-            citiesRequest.expectNetworkRequestToHaveBeenMade()
+            citiesRequest.expectRequestToHaveBeenMade()
         } catch (error) {
             expectedErrorWhenRequestNotMade = error
         }

--- a/src/tests/autoGeneratingGraphQLResponse.spec.ts
+++ b/src/tests/autoGeneratingGraphQLResponse.spec.ts
@@ -53,7 +53,7 @@ describe("Automatic generation of graphQL responses depending on query and suppl
                     }
                 }
             `)
-        mockedGQLRequestWithSchema.expectNetworkRequestToHaveBeenMade()
+        mockedGQLRequestWithSchema.expectRequestToHaveBeenMade()
         expectToMatchSchema(
             response.body as JsonObject,
             strictObject({
@@ -88,7 +88,7 @@ describe("Automatic generation of graphQL responses depending on query and suppl
                     }
                 }
             `)
-        mockedGQLRequestWithSchema.expectNetworkRequestToHaveBeenMade()
+        mockedGQLRequestWithSchema.expectRequestToHaveBeenMade()
         expectToMatchSchema(
             response.body as JsonObject,
             strictObject({
@@ -128,7 +128,7 @@ describe("Automatic generation of graphQL responses depending on query and suppl
                 nameToSearchBy: "Darth Vader",
             }
         )
-        mockedGQLRequestWithSchema.expectNetworkRequestToHaveBeenMade()
+        mockedGQLRequestWithSchema.expectRequestToHaveBeenMade()
         expectToMatchSchema(
             response.body as JsonObject,
             strictObject({
@@ -167,7 +167,7 @@ describe("Automatic generation of graphQL responses depending on query and suppl
                     }
                 }
             `)
-        mockedGQLRequestWithSchema.expectNetworkRequestToHaveBeenMade()
+        mockedGQLRequestWithSchema.expectRequestToHaveBeenMade()
         expect(response.body).toEqual(fixedResponse)
     })
 
@@ -191,7 +191,7 @@ describe("Automatic generation of graphQL responses depending on query and suppl
                     }
                 }
             `)
-        mockedGQLRequestWithSchema.expectNetworkRequestToHaveBeenMade()
+        mockedGQLRequestWithSchema.expectRequestToHaveBeenMade()
         expect((response.body as JsonObject).data.me.name).toEqual(customString)
     })
 
@@ -219,7 +219,7 @@ describe("Automatic generation of graphQL responses depending on query and suppl
           }
         }
             `)) as JsonObject
-        mockedGQLRequestWithSchema.expectNetworkRequestToHaveBeenMade()
+        mockedGQLRequestWithSchema.expectRequestToHaveBeenMade()
         expect(response.body.data.allStarships.edges[0].node.model).toBe(
             customString
         )
@@ -303,7 +303,7 @@ describe("Automatic generation of graphQL responses depending on query and suppl
                     }
                 }
             `)
-        mockedGQLRequestWithSchema.expectNetworkRequestToHaveBeenMade()
+        mockedGQLRequestWithSchema.expectRequestToHaveBeenMade()
         expect((response as JsonObject).body.data.users.length).toBe(
             fixedLength
         )
@@ -330,7 +330,7 @@ describe("Automatic generation of graphQL responses depending on query and suppl
                     }
                 }
             `)
-        mockedGQLRequestWithSchema.expectNetworkRequestToHaveBeenMade()
+        mockedGQLRequestWithSchema.expectRequestToHaveBeenMade()
         expect(
             (response as JsonObject).body.data.users.length
         ).toBeGreaterThanOrEqual(fixedLength[0])

--- a/src/tests/mockingGraphQL.spec.ts
+++ b/src/tests/mockingGraphQL.spec.ts
@@ -48,14 +48,14 @@ describe("Mocking graphQL requests", () => {
         const firstCalledButSecondMocked = await exampleGraphQLPostRequestJson(
             `query GetSecondThings { animals { cats } }`
         )
-        secondMockedRequest.expectNetworkRequestToHaveBeenMade()
+        secondMockedRequest.expectRequestToHaveBeenMade()
         firstMockedRequest.expectNetworkRequestToNotHaveBeenMade()
         expect(firstCalledButSecondMocked.body).toEqual(secondThings)
 
         const secondCalledButFirstMocked = await exampleGraphQLPostRequestJson(
             `query GetFirstThings { animals { cats } }`
         )
-        secondMockedRequest.expectNetworkRequestToHaveBeenMade()
+        secondMockedRequest.expectRequestToHaveBeenMade()
         expect(secondCalledButFirstMocked.body).toEqual(firstThings)
     })
 
@@ -74,11 +74,11 @@ describe("Mocking graphQL requests", () => {
         const firstCalledButSecondMocked = await exampleGraphQLGetRequestJson(
             `query GetSecondThings { animals { cats } }`
         )
-        secondMockedRequest.expectNetworkRequestToHaveBeenMade()
+        secondMockedRequest.expectRequestToHaveBeenMade()
         const secondCalledButFirstMocked = await exampleGraphQLGetRequestJson(
             `query GetFirstThings { animals { cats } }`
         )
-        firstMockedRequest.expectNetworkRequestToHaveBeenMade()
+        firstMockedRequest.expectRequestToHaveBeenMade()
 
         expect(firstCalledButSecondMocked.body).toEqual({
             entries: "two deux duo zwei",
@@ -88,7 +88,7 @@ describe("Mocking graphQL requests", () => {
         })
     })
 
-    it("expectNetworkRequestToHaveBeenMade() applies to the request that was made using the query name, order doesn't matter", async () => {
+    it("expectRequestToHaveBeenMade() applies to the request that was made using the query name, order doesn't matter", async () => {
         const firstReponse = {entries: "one une uno eins"}
         const secondResponse = {entries: "deux zwei two duo"}
         const firstMockedRequest = mockRequest({
@@ -104,7 +104,7 @@ describe("Mocking graphQL requests", () => {
 
         let expectedErrorOnCheckIfFirstMockedRequestWasCalled
         try {
-            firstMockedRequest.expectNetworkRequestToHaveBeenMade()
+            firstMockedRequest.expectRequestToHaveBeenMade()
         } catch (error) {
             expectedErrorOnCheckIfFirstMockedRequestWasCalled = error
         }
@@ -117,12 +117,12 @@ describe("Mocking graphQL requests", () => {
         const secondMockedCalled = await exampleGraphQLPostRequestJson(
             `query GetSecondThings { animals { cats } }`
         )
-        secondMockedRequest.expectNetworkRequestToHaveBeenMade()
+        secondMockedRequest.expectRequestToHaveBeenMade()
         expect(secondMockedCalled.body).toEqual(secondResponse)
 
         let expectedErrorOnCheckIfFirstMockedRequestWasStillNotCalled
         try {
-            firstMockedRequest.expectNetworkRequestToHaveBeenMade()
+            firstMockedRequest.expectRequestToHaveBeenMade()
         } catch (error) {
             expectedErrorOnCheckIfFirstMockedRequestWasStillNotCalled = error
         }
@@ -135,7 +135,7 @@ describe("Mocking graphQL requests", () => {
         const firstMockedCalled = await exampleGraphQLPostRequestJson(
             `query GetFirstThings { animals { cats } }`
         )
-        firstMockedRequest.expectNetworkRequestToHaveBeenMade()
+        firstMockedRequest.expectRequestToHaveBeenMade()
         expect(firstMockedCalled.body).toEqual(firstReponse)
     })
 

--- a/src/tests/stackTrace.spec.ts
+++ b/src/tests/stackTrace.spec.ts
@@ -18,11 +18,11 @@ const exampleRequestJson = async (
 const regexForErrorInThisFile = /Error: \n {4}at .+\/src\/tests\/stacktrace\.spec\.ts:\d+:\d+/i
 
 describe("Stack traces stop at calling function, don't include mock-inspect specifics", () => {
-    it("expectNetworkRequestToHaveBeenMade()", () => {
+    it("expectRequestToHaveBeenMade()", () => {
         const req = mockRequest({requestPattern: "/this/is/my/URL"})
         let expectedError
         try {
-            req.expectNetworkRequestToHaveBeenMade()
+            req.expectRequestToHaveBeenMade()
         } catch (error) {
             expectedError = error
         }


### PR DESCRIPTION
This PR renames `expectNetworkRequestToHaveBeenMade` to `expectRequestToHaveBeenMade`


See https://github.com/trayio/mock-inspect/issues/12 for details