### PR TITLE
[QA-2289] Remove Contract concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ await request(`query SecondQuery { animals { cats } }`)
 await request(`mutation FirstMutation(call: "Meow") { id }`)
 ```
 
-## mockRequestFromContract
+## mockRequestFromExample
 
-Mocks a request based on a contract and returns a [MockedRequest](#mockedrequest) object. A contract is an object which holds all the details of a network request - how it is supposed to be made and what it is supposed to return. [Check out the type definition](https://github.com/trayio/mock-inspect/blob/main/src/types/Contract.ts) for details of properties you can enter.
+Mocks a request based on an example and returns a [MockedRequest](#mockedrequest) object. An example is an object which holds all the details of a network request - how it is supposed to be made and what it is supposed to return. [Check out the type definition](https://github.com/trayio/mock-inspect/blob/main/src/types/Example.ts) for details of properties you can enter.
 
 ```js
-const {mockRequestFromContract} = require("mock-inspect")
+const {mockRequestFromExample} = require("mock-inspect")
 
-const loginContract = {
+const loginExample = {
     response: {
         statusCode: 201,
         body: "Welcome!",
@@ -92,9 +92,9 @@ const loginContract = {
         }
     }
 }
-const loginRequest = mockRequestFromContract(loginContract)
+const loginRequest = mockRequestFromExample(loginExample)
 // ... make a network request somewhere in your actual code ...
-loginRequest.expectRequestMadeMatchingContract()
+loginRequest.expectRequestToHaveBeenMade()
 ```
 
 ## MockedRequest
@@ -117,59 +117,6 @@ Asserts that the network request you mocked was not called.
 ```js
 const loginRequest = mockRequest({/* mock details go here */})
 loginRequest.expectRequestToNotHaveBeenMade()
-```
-
-### expectRequestMadeMatching
-
-Asserts that the network request you mocked was called with the expected properties. [Check out the type definition](https://github.com/trayio/mock-inspect/blob/main/src/types/ExpectRequestMadeMatchingInput.ts) for details of the properties you can provide here.
-
-If you created your mocked request from a contract, you most likely want to use [expectRequestMadeMatchingContract](##expectrequestmadematchingcontract) instead.
-
-```js
-const loginRequest = mockRequest({/* mock details go here */})
-loginRequest.expectRequestMadeMatching({
-    requestPayload: {
-        "username": "HanSolo",
-        "password": "Never tell me the odds!"
-    },
-    requestHeaders: {
-        "Authorization": "I provided my token in the request header"
-    }
-})
-```
-
-### expectRequestMadeMatchingContract
-
-Asserts that the network request you mocked was called with the expected properties as provided in the contract. [Check out the type definition](https://github.com/trayio/mock-inspect/blob/main/src/types/Contract.ts) for details of how a Contract looks like.
-
-If you create your MockedRequest object using `mockRequestFromContract`, you do not have to pass in any arguments to `expectRequestMadeMatchingContract`. If you created your MockedRequest using `mockRequest`, you have to pass in a contract though so that we can know what expectations you refer to.
-
-```js
-const loginContract = {
-    response: {
-        statusCode: 201,
-        body: "Welcome!",
-        headers: {
-            "Authorization": "take your token good sir!"
-        }
-    },
-    request: {
-        url: "https://www.yourwebsite.com/login",
-        method: "POST",
-        payload: {
-            "username": "HanSolo",
-            "password": "Never tell me the odds!"
-        }
-    }
-}
-
-// When created using mockRequestFromContract:
-const loginRequest = mockRequestFromContract(loginContract)
-loginRequest.expectRequestMadeMatchingContract()
-
-// When created using mockRequest:
-const loginRequest = mockRequest({/* mock details go here */})
-loginRequest.expectRequestMadeMatchingContract(loginContract)
 ```
 
 # Using GraphQL
@@ -234,9 +181,6 @@ await exampleGraphQLPostRequestJson(`
     }
 `)
 ```
-
-## Making graphQL contract assertions
-A note on comparing actual graphQL requests against your defined expectations: Whenever we realise that you created a mock using a URL that ended in `/graphql`, we will assume that you are using a GraphQL API. In order to compare the request payloads, we convert both payloads to JSON objects - basically a **reverse** version of the library [json-to-graphql-query](https://github.com/dupski/json-to-graphql-query). We can then compare these two objects against each other to check whether all properties have been set or whether some have been missing.
 
 # Setting up your test suite
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4303,29 +4303,6 @@
             "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
             "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
         },
-        "graphql-query-to-json": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/graphql-query-to-json/-/graphql-query-to-json-1.0.2.tgz",
-            "integrity": "sha512-ynmGX0C64qGpH23aovTFa8/PCRM2s+Do4/rt8s+C66+d9swxPrxwP23CO+9aUtFp1/BdsUsFZZ2Zq32gFadUoQ==",
-            "requires": {
-                "graphql": "^14.5.8",
-                "json-to-graphql-query": "^1.9.0",
-                "lodash.isarray": "^4.0.0",
-                "lodash.isobject": "^3.0.2",
-                "lodash.isstring": "^4.0.1",
-                "lodash.mapvalues": "^4.6.0"
-            },
-            "dependencies": {
-                "graphql": {
-                    "version": "14.7.0",
-                    "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
-                    "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
-                    "requires": {
-                        "iterall": "^1.2.2"
-                    }
-                }
-            }
-        },
         "graphql-tag": {
             "version": "2.12.3",
             "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.3.tgz",
@@ -5133,11 +5110,6 @@
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
             }
-        },
-        "iterall": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-            "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
         },
         "jest": {
             "version": "26.6.3",
@@ -6043,11 +6015,6 @@
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
         },
-        "json-to-graphql-query": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/json-to-graphql-query/-/json-to-graphql-query-1.9.0.tgz",
-            "integrity": "sha512-SXZzxv5J7AQgdmJBkq94mIStjDxuWmecLhsNYTENm+Fzil1qyt6PiKDvq4cHjFJKXB6Qp4TedZxElyRHr7oPYw=="
-        },
         "json5": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -6253,25 +6220,10 @@
             "integrity": "sha1-Cwih3PaDl8OXhVwyOXg4Mt90A9E=",
             "dev": true
         },
-        "lodash.isarray": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
-            "integrity": "sha1-KspJayjEym1yZxUxNZDALm6jRAM="
-        },
         "lodash.isobject": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
             "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
-        },
-        "lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-        },
-        "lodash.mapvalues": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-            "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
         },
         "lodash.sortby": {
             "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "license": "MIT",
     "dependencies": {
         "graphql": "^15.3.0",
-        "graphql-query-to-json": "1.0.2",
         "graphql-tools": "^7.0.4",
         "lodash.isobject": "^3.0.2",
         "msw": "^0.21.3",

--- a/src/MockedRequest.ts
+++ b/src/MockedRequest.ts
@@ -7,7 +7,7 @@ import {
     RequestResponseInfo,
 } from "./mockRequest"
 // eslint-disable-next-line no-unused-vars
-import {Contract} from "./types/Contract"
+import {Example} from "./types/Example"
 // eslint-disable-next-line no-unused-vars
 import {NetworkRequestHeaders} from "./types/generalTypes"
 import {MockedRequestInfo} from "./types/MockedRequestInfo"

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
     MockResponseOptions,
 } from "./types/MockResponseOptions"
 // eslint-disable-next-line no-unused-vars
-import {Contract} from "./types/Contract"
+import {Example} from "./types/Example"
 export {MockedRequest} from "./MockedRequest"
 import {mockRequestBase} from "./mockRequest"
 import {generateStacktraceWithoutMockedRequestInfo} from "./utils"
@@ -16,15 +16,15 @@ export const mockRequest = (mockOpts: MockResponseOptions): MockedRequest => {
     return mockRequestBase({mockOpts, stacktrace})
 }
 
-export const mockRequestFromContract = (contract: Contract): MockedRequest => {
+export const mockRequestFromExample = (example: Example): MockedRequest => {
     const stacktrace = generateStacktraceWithoutMockedRequestInfo()
     return mockRequestBase({
         mockOpts: {
-            requestPattern: contract.request.url,
-            responseStatus: contract.response.statusCode,
-            responseBody: contract.response.body,
-            requestMethod: contract.request.method,
-            responseHeaders: contract.response.headers,
+            requestPattern: example.request.url,
+            responseStatus: example.response.statusCode,
+            responseBody: example.response.body,
+            requestMethod: example.request.method,
+            responseHeaders: example.response.headers,
         },
         stacktrace,
     })

--- a/src/mockRequest.ts
+++ b/src/mockRequest.ts
@@ -8,7 +8,6 @@ import {NetworkResponseBody, HttpMethod, NetworkRequestHeaders} from "./types/ge
 /* eslint-enable no-unused-vars */
 import {handleGraphQLRequest} from "./responseHandlers/graphql"
 import {handleRestRequest} from "./responseHandlers/rest"
-export {Contract} from "./types/Contract"
 export {MockedRequest} from "./MockedRequest"
 // eslint-disable-next-line no-unused-vars
 import {MswUsedRequestHeaders} from "./utils"

--- a/src/tests/mockRequestFromContract.spec.ts
+++ b/src/tests/mockRequestFromContract.spec.ts
@@ -1,15 +1,15 @@
-import {mockRequestFromContract} from ".."
+import {mockRequestFromExample} from ".."
 import {
     request,
     // eslint-disable-next-line no-unused-vars
     RequestHelperResponse,
 } from "./testHelpers/requestHelpers"
 // eslint-disable-next-line no-unused-vars
-import {Contract} from "../types/Contract"
+import {Example} from "../types/Example"
 // eslint-disable-next-line no-unused-vars
 import {NetworkRequestBody} from "../types/generalTypes"
 
-const citiesContract: Contract = {
+const citiesExample: Example = {
     response: {
         statusCode: 200,
         body: {
@@ -43,17 +43,17 @@ const exampleRequestJson = async (
     payload: NetworkRequestBody = undefined
 ): Promise<RequestHelperResponse> => {
     return await request({
-        uri: citiesContract.request.url,
-        method: citiesContract.request.method,
+        uri: citiesExample.request.url,
+        method: citiesExample.request.method,
         json: true,
         body: payload,
     })
 }
 
-describe("mockRequestFromContract examples", () => {
-    it("Can mock a basic GET request from provided contract", async () => {
-        mockRequestFromContract(citiesContract)
+describe("mockRequestFromExample", () => {
+    it("Can mock a basic GET request from provided example", async () => {
+        mockRequestFromExample(citiesExample)
         const res = await exampleRequestJson()
-        expect(res.body).toEqual(citiesContract.response.body)
+        expect(res.body).toEqual(citiesExample.response.body)
     })
 })

--- a/src/types/Example.ts
+++ b/src/types/Example.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-unused-vars
 import {NetworkRequestBody, HttpMethod, NetworkRequestHeaders} from "./generalTypes"
 
-export type Contract = {
+export type Example = {
     response: {
         statusCode: number
         body?: any
@@ -13,10 +13,10 @@ export type Contract = {
         headers?: NetworkRequestHeaders
         payload?: NetworkRequestBody
     }
-    metadata?: AdditionalContractInfo
+    metadata?: AdditionalExampleInfo
 }
 
-interface AdditionalContractInfo {
+interface AdditionalExampleInfo {
     testName?: string
     date: string
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,11 +2,9 @@ import * as jestExpect from "expect"
 import * as isObject from "lodash.isobject"
 // eslint-disable-next-line no-unused-vars
 import {
-    NetworkRequestBody,
     JsonObject,
     NetworkRequestHeaders,
 } from "../types/generalTypes"
-import {graphQlQueryToJson} from "graphql-query-to-json"
 // eslint-disable-next-line no-unused-vars
 import {RequestResponseInfo} from "../mockRequest"
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
This renames all instances of "contract" to "example", as per discussion with @thomaschaplin. This pull request is not yet the task to update the README but I have already removed instances in the readme relating to the previously removed methods as it would have been unsensible to rename "contract" to "example" in these cases if I would remove them later on anyway.