### PR TITLE
[Issue 68] Don't lowercase request headers returned by inspect

### DIFF
--- a/src/tests/assertionHelpers.spec.ts
+++ b/src/tests/assertionHelpers.spec.ts
@@ -66,7 +66,7 @@ describe("Assertion Helpers", () => {
             const requestInfo = citiesRequest.inspect()
             expect(requestInfo.requestBody).toEqual(bodyUsed)
             expect(requestInfo.requestHeaders.header_name_1).toBe(
-                "header_value_1"
+                "HEADER_VALUE_1"
             )
         })
 

--- a/src/tests/utilsTests/utils.spec.ts
+++ b/src/tests/utilsTests/utils.spec.ts
@@ -1,4 +1,4 @@
-import {objectHasKeys, normaliseRequestHeaderObject} from "../../utils"
+import {objectHasKeys} from "../../utils"
 
 describe("Utils", () => {
     describe("Object has keys helper", () => {
@@ -8,38 +8,6 @@ describe("Utils", () => {
 
         it("Returns false if an object without keys is passed in", () => {
             expect(objectHasKeys({})).toBe(false)
-        })
-    })
-
-    describe("Normalise request header object helper", () => {
-        it("Converts header values to lower-case if passed as regular string", () => {
-            expect(
-                normaliseRequestHeaderObject({
-                    KeyA: "PropertyA",
-                })
-            ).toEqual({
-                keya: "propertya",
-            })
-        })
-        it("Converts header values to lower-case if passed as array", () => {
-            expect(
-                normaliseRequestHeaderObject({
-                    KeyA: ["PropertyA"],
-                })
-            ).toEqual({
-                keya: "propertya",
-            })
-        })
-        it("Converts header values to lower-case if mixed", () => {
-            expect(
-                normaliseRequestHeaderObject({
-                    KeyA: "PropertyA",
-                    KeyB: ["Poperty B"],
-                })
-            ).toEqual({
-                keya: "propertya",
-                keyb: "poperty b",
-            })
         })
     })
 })

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -37,11 +37,9 @@ export const normaliseRequestHeaderObject = (
     Object.keys(requestHeaders).forEach((header) => {
         const headerName = header.toLowerCase()
         if (Array.isArray(requestHeaders[header])) {
-            headers[headerName] = requestHeaders[header][0].toLowerCase()
+            headers[headerName] = requestHeaders[header][0]
         } else {
-            headers[headerName] = (requestHeaders[
-                header
-            ] as string).toLowerCase()
+            headers[headerName] = requestHeaders[header] as string
         }
     })
     return headers


### PR DESCRIPTION
This prevents request headers from being lower-cased when returned by inspect(). inspect() should simply return the values how they were used.

This fixes #68

Would you be able to release this for me as **patch** version @thomaschaplin ?