### PR TITLE
Remove unnecessary expect dependency

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -59,7 +59,7 @@ export const compareRequestMadeStatusAgainstExpectation = (
     expectation: boolean,
     stacktrace: string
 ) => {
-    if (hasRequestBeenDone != expectation) {
+    if (hasRequestBeenDone !== expectation) {
         throwErrorWithFixedStacktrace(
             constructRequestMadeStatusErrorMessage(expectation),
             stacktrace

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,3 @@
-import * as jestExpect from "expect"
 import * as isObject from "lodash.isobject"
 // eslint-disable-next-line no-unused-vars
 import {JsonObject, NetworkRequestHeaders} from "../types/generalTypes"
@@ -60,9 +59,7 @@ export const compareRequestMadeStatusAgainstExpectation = (
     expectation: boolean,
     stacktrace: string
 ) => {
-    try {
-        jestExpect(hasRequestBeenDone).toBe(expectation)
-    } catch (error) {
+    if (hasRequestBeenDone != expectation) {
         throwErrorWithFixedStacktrace(
             constructRequestMadeStatusErrorMessage(expectation),
             stacktrace


### PR DESCRIPTION
This dependeny prevented the module to work with mocha. Reason: When running tests with jest, the dependency "expect" is already in your `node_modules` and thus node can use it even though it wasn't installed via package.json. But with mocha, this dependency is not in the `node_modules` tree.

I could have added `expect` as a dependency to package.json or removed it entirely. I decided to remove it as it was only used in one place - a leftover from the old days.